### PR TITLE
C2C-13: Added a configuration folder with 2 locations

### DIFF
--- a/configuration/locations/locations.csv
+++ b/configuration/locations/locations.csv
@@ -1,0 +1,3 @@
+Uuid,Void/Retire,Name,Description,Parent,Tags,Address 1,Address 2,Address 3,Address 4,Address 5,Address 6,City/Village,County/District,State/Province,Postal Code,Country,_order:1000
+a42fc3f0-c4ca-42b8-8144-3c95949d8c5b,,C2C Hospital,,,Login Location; Visit Location; Admission Location; Appointment Location,,,,,,,,,,,,
+49780ca0-8931-11e9-bab0-47c7bc1d8a31,,Inpatient Ward,,a42fc3f0-c4ca-42b8-8144-3c95949d8c5b,Visit Location; Admission Location,,,,,,,,,,,,


### PR DESCRIPTION
Added a configuration folder with 2 locations (C2C Hospital and Inpatient Ward).
I followed the configurations we have for [CHIDA](https://github.com/mekomsolutions/openmrs-config-chida/tree/master/configuration/locations)